### PR TITLE
Add https://nft.storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Table of contents
  - [Scaffold-eth (everything you need for DApp & NFT development)](https://github.com/austintgriffith/scaffold-eth)
  - [Ethermore (An emerging fantasy world, built on the blockchain)](https://ethermore.xyz/)
  - [Authenticated Non-Fungible Tokens (NFT) Index](https://nftndx.io/)
+ - [nft.storage (free decentralized storage for NFTs on IPFS & Filecoin)](https://nft.storage/)
 
 ## **Distributed Ledgers**
 


### PR DESCRIPTION
Adds https://nft.storage: a service for storing off-chain NFT data on IPFS and Filecoin.

see: https://filecoin.io/blog/posts/introducing-nft.storage-free-decentralized-storage-for-nfts/